### PR TITLE
Handle unmatched overview village rows

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,62 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pages.overview import OverviewPage, Point
+
+
+class FakeResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class FakeWrapper:
+    def __init__(self, text: str):
+        self._text = text
+
+    def get_url(self, url: str):
+        return FakeResponse(self._text)
+
+
+class OverviewPageParsingTests(unittest.TestCase):
+    def test_parse_production_table_skips_unexpected_name_formats(self):
+        html = """
+        <html>
+            <body>
+                <table id="production_table">
+                    <tr>
+                        <td><span class="quickedit"></span><span data-id="123">Normal Village (500|500) K55</span></td>
+                        <td>1.234</td>
+                        <td>1.000 2.000 3.000</td>
+                        <td>4000</td>
+                        <td>100/200</td>
+                    </tr>
+                    <tr>
+                        <td><span class="quickedit"></span><span data-id="456">Seltsames Dorf (Sondername 501|501) K55</span></td>
+                        <td>2.345</td>
+                        <td>4.000 5.000 6.000</td>
+                        <td>5000</td>
+                        <td>150/200</td>
+                    </tr>
+                </table>
+            </body>
+        </html>
+        """
+        page = OverviewPage(FakeWrapper(html))
+
+        self.assertIn("123", page.villages_data)
+        self.assertNotIn("456", page.villages_data)
+
+        village = page.villages_data["123"]
+        self.assertEqual(village.village_name, "Normal Village")
+        self.assertEqual(village.coordinates, Point(500, 500))
+        self.assertEqual(village.continent, "K55")
+        self.assertEqual(village.points, 1234)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- guard parsing of production table rows by validating extracted village details before unpacking and logging skipped entries
- return `None` from `_extract_name_cords_continent` when the village pattern is not matched to avoid crashes
- add a unit test covering a production table row with an unusual village name to ensure rows are skipped safely

## Testing
- python -m unittest tests.test_overview

------
https://chatgpt.com/codex/tasks/task_e_68cbea13ebe48325b8f54bec02d1db41