### PR TITLE
Handle missing API responses gracefully

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -151,6 +151,18 @@ class WebWrapper:
         response = self.get_url(url)
         return response
 
+    def _parse_api_response(self, response, context):
+        """Return parsed JSON data for API requests when possible."""
+        if response is None:
+            self.logger.warning("No response received for %s", context)
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            return response
+
     def get_api_data(self, village_id, action, params={}):
 
         custom = dict(self.headers)
@@ -166,11 +178,10 @@ class WebWrapper:
         payload = f"game.php?{urlencode(req)}"
         url = urljoin(self.endpoint, payload)
         res = self.get_url(url, headers=custom)
-        if res.status_code == 200:
-            try:
-                return res.json()
-            except:
-                return res
+        return self._parse_api_response(
+            res,
+            f"get_api_data(action={action}, village={village_id})",
+        )
 
     def post_api_data(self, village_id, action, params={}, data={}):
         """
@@ -191,11 +202,10 @@ class WebWrapper:
         if 'h' not in data:
             data['h'] = self.last_h
         res = self.post_url(url, data=data, headers=custom)
-        if res.status_code == 200:
-            try:
-                return res.json()
-            except:
-                return res
+        return self._parse_api_response(
+            res,
+            f"post_api_data(action={action}, village={village_id})",
+        )
 
     def get_api_action(self, village_id, action, params={}, data={}):
         """
@@ -216,9 +226,7 @@ class WebWrapper:
         if 'h' not in data:
             data['h'] = self.last_h
         res = self.post_url(url, data=data, headers=custom)
-        if res.status_code == 200:
-            try:
-                return res.json()
-            except:
-                return res
-        return None
+        return self._parse_api_response(
+            res,
+            f"get_api_action(action={action}, village={village_id})",
+        )

--- a/game/troopmanager.py
+++ b/game/troopmanager.py
@@ -613,7 +613,14 @@ class TroopManager:
             params={"screen": building, "mode": "train"},
             data={"units[%s]" % unit_type: str(amount)},
         )
-        if "game_data" in result:
+        if result is None:
+            self.logger.warning(
+                "Recruitment of %d %s failed because the server returned no response",
+                amount,
+                unit_type,
+            )
+            return False
+        if isinstance(result, dict) and "game_data" in result:
             self.resman.update(result["game_data"])
             self.wait_for[self.village_id][building] = int(time.time()) + (
                     amount * int(resources["build_time"])

--- a/game/village.py
+++ b/game/village.py
@@ -638,6 +638,9 @@ class Village:
             village_id=self.village_id,
             params={"screen": 'new_quests', "tab": "main-tab", "quest": 0},
         )
+        if result is None:
+            self.logger.warning("Failed to fetch quest reward data from API")
+            return False
         # The data is escaped for JS, so unescape it before sending it to the extractor.
         rewards = Extractor.get_quest_rewards(decode(result["response"]["dialog"], 'unicode-escape'))
         for reward in rewards:


### PR DESCRIPTION
## Summary
- add a helper in `WebWrapper` to parse API responses safely
- return early when API requests do not provide a response and log the issue
- guard quest reward and troop recruitment flows against missing API data

## Testing
- python -m compileall core game

------
https://chatgpt.com/codex/tasks/task_e_68cbea13de308325a88fea47b01cc1d0