### PR TITLE
Füge Unterstützung für den Farm-Beutelimit-Schutz hinzu und aktualisi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ celerybeat.pid
 .env
 .venv
 env/
+env/**
 venv/
 ENV/
 env.bak/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `twb.py` boots the bot, reads `config.json`, and wires the managers.
+- `core/` hosts shared services for HTTP, caching, I/O, and notifications.
+- `game/` implements farming, defence, recruitment, and simulation logic.
+- `webmanager/` contains the Flask dashboard plus its `static/` and `templates/`.
+- `templates/` holds build/troop presets; keep custom presets beside their variants.
+- `tests/` stores `unittest` suites; `cache/` is runtime-only and should remain ignored.
+
+## Build, Test, and Development Commands
+- `python -m venv env` with the platform-appropriate activate script creates an isolated environment.
+- `pip install -r requirements.txt` installs bot and dashboard dependencies.
+- `python twb.py` runs the bot and, if needed, triggers the first-run wizard.
+- `python -m webmanager.server` serves the local dashboard for monitoring.
+- `python -m unittest discover -s tests -p "test_*.py"` runs all tests; add `-v` while debugging.
+
+## Coding Style & Naming Conventions
+- Adhere to PEP 8, 4-space indentation, and snake_case module and member names.
+- Add type hints and focused docstrings where modules in `core/`, `game/`, and `webmanager/` interact.
+- Use the existing `logging.getLogger(...)` pattern; avoid stray prints.
+- Keep configuration keys lower_snake_case as shown in `config.example.json`.
+
+## Testing Guidelines
+- Expand `unittest` cases to cover new parsing paths and automation branches.
+- Name files and methods `test_*`; keep realistic HTML/JSON fixtures near the tests.
+- Run `python -m unittest` before each PR and add targeted assertions for new logic.
+
+## Commit & Pull Request Guidelines
+- Write concise imperative subjects (e.g., `Handle missing API responses`) and elaborate in the body if required.
+- Flag config or template changes so reviewers can validate behaviour.
+- In PRs, link issues, attach dashboard screenshots for UI tweaks, and state the test command executed.
+
+## Configuration & Security Tips
+- Copy `config.example.json` when onboarding; never commit personal credentials or village data.
+- Treat `config.bak` as local only and purge `cache/` artifacts before sharing branches.
+- Store secrets in environment variables or ignored `.env` files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Added configurable Farm-Beutelimit-Schutz – der Farm-Manager stoppt Farm- und Scout-Läufe automatisch, sobald das Weltlimit erreicht ist (inkl. Margin/Overrides).
+
 ### New in 1.6
 - Bugfixes
 - Found the bug where villages were not detected automatically

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ TWB bietet eine breite Palette an Funktionen, die eine umfassende Automatisierun
 *   **Farm-Manager:**
     *   Sucht und farmt automatisch Barbarendörfer in der Umgebung.
     *   **Intelligente Optimierung:** Analysiert Berichte, um die Effizienz zu bewerten. Passt die Farmziele und Angriffspausen dynamisch an (z.B. längere Pausen für Dörfer mit wenig Beute oder hohen Verlusten).
+    *   **Beutelimit-Schutz:** Überwacht das weltweite Farm-Beutelimit auf der Place-Seite und verhindert weitere Farm- oder Scout-Befehle, wenn das Limit (inkl. Sicherheitsmarge) erreicht ist.
 *   **Marktplatz-Manager:** Gleicht Ressourcen zwischen den Dörfern automatisch aus, um Engpässe zu vermeiden und den Bau zu beschleunigen.
 *   **Forschungs-Manager:** Führt automatisch Forschungen in der Schmiede durch, sobald die Voraussetzungen erfüllt sind.
 *   **Automatische Adelung:** Prägt Münzen und adelt vollautomatisch neue Dörfer.
@@ -104,6 +105,7 @@ Allgemeine Einstellungen zum Verhalten des Bots.
 *   `"inactive_still_active"`: Wenn `true`, führt der Bot auch im inaktiven Modus weiterhin Aktionen aus, nur eben langsamer. Wenn `false`, stoppt der Bot komplett und deine Sitzung läuft wahrscheinlich ab.
 *   `"add_new_villages"`: Wenn `true`, werden neu eroberte Dörfer automatisch zur Konfiguration hinzugefügt, wobei die Einstellungen aus `village_template` übernommen werden.
 *   `"user_agent"`: Dein Browser-User-Agent. **Sehr wichtig, um das Entdeckungsrisiko zu senken.**
+*   `"farm_bag_limit_margin"`: Prozentualer Sicherheitsabstand (zwischen 0.0 und 0.2) zum Welt-Beutelimit, ab dem keine weiteren Farm- oder Scout-Befehle mehr ausgelöst werden.
 
 ---
 
@@ -137,6 +139,7 @@ Dies ist eine Vorlage für alle neu hinzugefügten Dörfer. Jedes Dorf in der `"
 *   `"prioritize_building"`: Wenn `true`, wird die Rekrutierung pausiert, bis die Bauschleife voll ist.
 *   `"prioritize_snob"`: Wenn `true`, reserviert der Bot Ressourcen für die Münzprägung und den Bau von Adelsgeschlechtern.
 *   `"snobs"`: Die maximale Anzahl an AGs, die in diesem Dorf gebaut werden sollen.
+*   `"farm_bag_limit_override"`: Setze `true` oder `false`, um das globale Farm-Beutelimit für dieses Dorf explizit zu aktivieren bzw. zu deaktivieren. `null` übernimmt die globale Einstellung.
 *   `"additional_farms"`: Eine Liste von Dorf-IDs (als Strings), die zusätzlich zu den automatisch gefundenen Barbarendörfern gefarmt werden sollen. **Vorsicht:** Der Bot prüft nicht, wem diese Dörfer gehören!
 *   `"gather_enabled"`: Wenn `true`, schickt der Bot Truppen zum Sammeln, wenn sie nicht für Angriffe oder Farmen gebraucht werden.
 
@@ -168,6 +171,8 @@ Einstellungen für den Marktplatz.
 Diese Optionen werden vom Bot normalerweise automatisch erkannt und gesetzt.
 
 *   `"knight_enabled"`, `"flags_enabled"`, `"quests_enabled"`, etc.: `true` oder `false`, je nachdem, welche Features die Spielwelt hat.
+*   `"farm_bag_limit_enabled"`: Aktiviert den Farm-Beutelimit-Schutz für alle Dörfer (sofern kein Dorf-Override gesetzt ist).
+*   `"farm_bag_block_scouts"`: Falls `true`, werden auch Scout-Läufe gestoppt, sobald das Limit erreicht ist.
 
 ---
 

--- a/activate_env.bat
+++ b/activate_env.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+call env\Scripts\activate.bat
+cmd /k

--- a/analysefertig.md
+++ b/analysefertig.md
@@ -1,0 +1,86 @@
+# TWB Codebase Analyse – 20.09.2025
+
+## Schritt 1 – Architekturüberblick
+- Einstieg über `twb.py` mit der Klasse `TWB`, die Konfiguration, HTTP-Sitzung und Dorfzyklen orkestriert (`twb.py:39`, `twb.py:279`).
+- Gemeinsame Infrastruktur liegt in `core/` (Datei- und HTTP-Wrapper, Benachrichtigungen, Templates, Updater).
+- Spiellogik konzentriert sich in `game/` (Dorf-, Truppen-, Bau-, Farm- und Verteidigungsmanager).
+- `pages/overview.py` kapselt HTML-Parsing für die Ingame-Übersicht, liefert strukturierte Welt- und Dorfdaten.
+- `webmanager/` stellt ein Flask-Dashboard inklusive Cache-Lesern, Template-Editor und Bot-Steuerung bereit (`webmanager/server.py:1`).
+- Persistente Nebenprodukte liegen in `cache/` (Sessions, Karten, Reports, Managed-Villages). Tests und Fixtures befinden sich unter `tests/`.
+
+## Schritt 2 – Steuerung & Konfigurationspflege
+### 2.1 Hauptschleife (`TWB.run`)
+- Prüft Konnektivität, läd Konfiguration, installiert Logging und initialisiert `WebWrapper` samt Reporter (`twb.py:279-320`).
+- Baut Dorfobjekte aus der Konfiguration und synchronisiert gefundene Ingame-Dörfer mit `OverviewPage` (`twb.py:321-355`).
+- Iteriert endlos über Dorfläufe, synchronisiert Verteidigungsstatus und ruft den globalen Farm-Manager auf (`twb.py:361-412`).
+- Schlafzyklen variieren je nach Aktiv-/Inaktiv-Zeitfenstern (aktive Tarnung) (`twb.py:399-417`).
+
+### 2.2 Konfigurationslogik
+- `TWB.config` liest `config.json`, führt bei Bedarf den manuellen Setup-Dialog und merged Versionsänderungen mit `config.example.json` (`twb.py:166-208`).
+- `merge_configs` übernimmt nutzerspezifische Werte, ergänzt neue Default-Schlüssel und synchronisiert Dorfvorlagen (`twb.py:200-207`).
+- Weltoptionen (z. B. Ritter, Flaggen) werden aus dem HTML-Header gelesen und bei Änderungen sofort in `config.json` zurückgeschrieben (`twb.py:243-267`).
+
+## Schritt 3 – HTTP- und Sitzungsmanagement
+- `WebWrapper` kapselt eine `requests`-Session, erneuert XSRF-Token, Referer und Parameter `h` nach jeder Antwort (`core/request.py:48-62`).
+- Standard-Header werden dynamisch um User-Agent und Ursprungsdomäne ergänzt, Delays werden randomisiert für Tarnung (`core/request.py:64-109`).
+- `start()` versucht Sitzungs-Cookies aus `cache/session.json` wiederzuverwenden, bittet andernfalls um manuelle Cookie-Zufuhr und persistiert sie (`core/request.py:116-144`).
+- API-Hilfen (`get_api_data`, `post_api_data`, `get_api_action`) injizieren Ajax-Header und nutzen `last_h`, um ingame AJAX-Endpoints zu simulieren (`core/request.py:166-215`).
+
+## Schritt 4 – Dorfzyklus im Detail (`Village.run`)
+1. **Initialisierung & Zustände** – Liest `game.php`-Übersicht, setzt Loggernamen, meldet Start ans Reporting (`game/village.py:146-190`).
+2. **Weltkontext** – Deaktiviert Einheiten anhand der Welt-Flags (z. B. Archers, Belagerung) und optional TWStats-Abgleich (`game/village.py:209-241`).
+3. **Vorbereitende Manager** – Aktualisiert Ressourcen (`ResourceManager`), Reports (`ReportManager`) und Defensiveinheit (`DefenceManager`), inklusive Angriffsstatus (`game/village.py:243-306`).
+4. **Quest-Automation** – Sucht abgeschlossene Quests, claimt Belohnungen über AJAX, achtet auf Lagerkapazität (`game/village.py:332-382`, `game/village.py:606-638`).
+5. **Bauplanung** – Lädt Bauvorlage (global oder Dorf-Override), synchronisiert Queue, nutzt Schnellbau wenn verfügbar (`game/village.py:242-338`, `game/buildingmanager.py:61-134`).
+6. **Truppen & Forschung** – Lädt Truppenvorlage, setzt Wunschbestände, startet Rekrutierungen inkl. Prioritäten (Bauen, Adelsgeschlecht) (`game/village.py:340-417`).
+7. **Ressourcensteuerung** – Entfernt leere Requests, loggt Bestände, prüft Premiumhandel (`game/village.py:419-547`).
+8. **Farming** – Aktualisiert Kartencache, synchronisiert Schweigefristen, wählt Targets anhand Punkte, Distanz und Cache-Daten (`game/village.py:452-512`, `game/attack.py:147-329`).
+9. **Nebentätigkeiten** – Ressourcensammeln (Gather), Marktsteuerung inkl. Premiumbörse (`game/village.py:500-547`).
+10. **Persistenz & Reporting** – Schreibt `cache/managed/<id>.json`, sendet Kennzahlen (Res, Gebäude, Truppen, Dorfkonfig) an Reporter (`game/village.py:597-618`).
+
+## Schritt 5 – Manager-Subsysteme
+- **BuildingManager**: Holt Kosten und Bau-IDs, überprüft Queue-Längen, fügt bei Ressourcendefizit automatisch Lager in Vordergrund ein (`game/buildingmanager.py:61-200`).
+- **TroopManager**: Ermittelt Live-Bestand via Platz-Übersicht, randomisiert Rekrutierungssätze, beachtet Wartezeiten pro Gebäude (`game/troopmanager.py:78-157`).
+- **AttackManager**: Bewertet sichere Ziele per Cache/Reports, sendet Farm-Läufe inklusive Scouts und forced-peace-Kontrolle, aktualisiert Cache nach jedem Angriff (`game/attack.py:97-329`).
+- **ResourceManager**: Reserviert Ressourcen pro Aktion, steuert Premiumbörse mit Optimierungslogik (Meta-Heuristik für Handelsvolumen) (`game/resources.py:120-220`).
+- **DefenceManager**: Ermittelt Angriffe via Übersichtsseite, koordiniert Flaggenwechsel, Evakuierung und Unterstützungsversand (`game/defence_manager.py:71-190`).
+- **ReportManager**: Parst Berichte, extrahiert Verluste/Loot, füttert Farm-Bewertungen und pflegt Cache (`game/reports.py:95-200`).
+- **VillageManager.farm_manager**: Globaler Evaluationslauf nach jedem Zyklus, bewertet Loot/Loss-Verhältnis, schaltet Farmprofile zwischen High/Low/Safe (`manager.py:12-110`).
+
+## Schritt 6 – Unterstützende Komponenten & Dashboard
+- **Notification** sendet Telegram-Nachrichten asynchron, liest Tokens aus Konfiguration (`core/notification.py:1-43`).
+- **Reporter** abstrahiert Datei- oder MySQL-Logging, inkl. Setup der Tabellen (`core/reporter.py:19-143`).
+- **TemplateManager** lädt Text- oder JSON-Vorlagen aus `templates/` (`core/templates.py:9-22`).
+- **TwStats** aktualisiert Farm-Populationsdaten via TWStats-Webscraping und cached Resultate (`core/twstats.py:17-86`).
+- **Flask-Dashboard** (`webmanager/server.py:1-210`): Stellt Konfigeditor mit HTML-Rendering bereit, liest Caches (`DataReader.cache_grab`) und steuert Bot-Start via `BotManager.start()`.
+
+## Schritt 7 – Beobachtungen & Besonderheiten
+- **Manuelle Sessionpflege**: Bot hängt von manuell kopierten Browser-Cookies ab; fehlende Automatisierung erschwert 24/7-Betrieb (`core/request.py:124-144`).
+- **Konfigurations-Roundtrips**: Jeder Hauptloop lädt `config.json` erneut, wodurch externe Änderungen unmittelbar greifen, aber I/O overhead entsteht (`twb.py:345-352`).
+- **Gemeinsamer ReportManager**: Erstes Dorf initialisiert `rep_man`, danach werden Instanzen geteilt – reduziert Requests, erfordert aber Thread-Sicherheit falls Parallelisierung geplant ist (`twb.py:361-365`).
+- **Zufallsverhalten**: Viele Delays beruhen auf `random.randint`, erzeugen menschlichere Muster, erschweren jedoch deterministisches Debugging (`twb.py:295-337`).
+- **Cache-Abhängigkeit**: Farming und Verteidigungsentscheidungen basieren stark auf `cache/`-Dateien; Datenkorruption oder fehlende Write-Rechte führen schnell zu Fehlentscheidungen.
+- **Event-Timer**: Forced-Peace-Zeiträume werden hart aus Konfiguration gelesen (`game/village.py:401-448`), keine UI-Unterstützung im Dashboard.
+
+## Schritt 8 – Web-Recherche: Trends & Optimierungspotenziale
+- **Anti-Detection-Infrastruktur**: Moderne Anti-Detect-Browser wie Dolphin Anty/Nstbrowser erlauben granulare Fingerprint-Steuerung, API-Automation und Proxy-Management – relevant für Cookie-Handling und Bot-Betrieb außerhalb klassischer Browser  citeturn0search10turn0search3turn0search6.
+- **Automation-Hardening**: Aktuelle Leitfäden zu Puppeteer/Selenium empfehlen menschliche Input-Mimik, Request-Interception und Stealth-Plugins, um Headless-Erkennung zu reduzieren  citeturn0search0turn0search1turn0search4turn0search5turn0search7.
+- **Proxymanagement**: Rotierende Residential/Mobile-Proxies bleiben Schlüssel gegen IP-Bans laut Anti-Bot-Trendberichten 2025  citeturn0search2.
+- **Meta-Reinforcement-Learning**: Neue Meta-DRL-Ansätze verbessern Ressourcenallokation in dynamischen Umgebungen signifikant (z. B. 19,8 % Effizienzgewinn) und könnten Farming-/Bau-Planung adaptiver machen  citeturn0academia11turn0academia14.
+- **RL-Task-Allocation**: Zweistufige RL-Frameworks adressieren dynamische Aufgabenvergabe mit guter Generalisierung – übertragbar auf simultane Dorfpriorisierung  citeturn0academia12turn0academia13.
+- **Community-Regeln**: Aktuelle Diskussionen in TW-Communities zeigen, dass Automationshilfen mit restriktiven Timer-Funktionen als grenzwertig gelten – Compliance-Check bleibt Pflicht  citeturn0reddit15.
+
+## Schritt 9 – Konkrete Vorschläge
+1. **Automatisierter Sitzungswechsel** – Integration eines Anti-Detect-Browsers via API zur Cookie-Synchronisation und Fingerprint-Rotation vor jedem Lauf; reduziert Bannrisiko und erleichtert 24/7-Drift  citeturn0search10turn0search6.
+2. **Adaptive Verzögerungen** – Ersetzen starrer `random.randint`-Delays durch ein Modul, das Nutzungsverhalten (Tageszeit, vergangene Aktionen) modelliert und Headless-Stealth-Empfehlungen befolgt  citeturn0search1turn0search4.
+3. **Proxy-Orchestrierung** – Einbindung eines Proxy-Pools mit Rotation und Qualitätsmetriken über `core/request`, inkl. Residential/Mobile-Fallbacks  citeturn0search2.
+4. **Meta-RL für Dorfpriorisierung** – Prototyp eines Meta-RL-Agenten, der Ressourcenzuteilung (Bauen vs. Rekrutieren vs. Farming) anhand Cache-Daten und Rewards lernt; zunächst als Simulation gegen historische Logs  citeturn0academia11turn0academia12.
+5. **Task-Allokations-Pipeline** – Übertrag der zweistufigen RL-Strategie auf Multi-Dorf-Farming: Phase 1 bewertet Dörfer, Phase 2 weist Farm-Templates und Scouting zu  citeturn0academia13.
+6. **Dashboard-Erweiterung** – Ergänzung um Forced-Peace-Editor, Delay-Profile und Proxy-Monitoring, damit operative Änderungen ohne Config-Edit erfolgen.
+7. **Compliance-Governance** – Dokumentation der Automationsfeatures mit Verweis auf Serverregeln; Option zum Umschalten auf „Safe Mode“ mit reduzierter Automation für restriktive Welten  citeturn0reddit15.
+
+## Schritt 10 – Nächste Schritte
+- Priorisierung der Vorschläge mit Fokus auf Risiko (Detection) vs. Aufwand.
+- Proof-of-Concept für RL-basierte Ressourcensteuerung anhand bestehender Cache-Historie.
+- Evaluierung von Anti-Detect-Browser-APIs (Dolphin Anty, AdsPower) auf Automatisierungsfähigkeit und Kostenmodell.
+- Ergänzende Tests für Edge-Cases (verwaiste Cache-Dateien, Config-Merges) zur Stabilitätsabsicherung.

--- a/config - Kopie.json.bak
+++ b/config - Kopie.json.bak
@@ -5,8 +5,8 @@
     "author": "stefan2200"
   },
   "server": {
-    "server": "nlc1",
-    "endpoint": "https://nlc1.tribalwars.nl/game.php",
+    "server": "de244",
+    "endpoint": "https://de244.die-staemme.de/game.php",
     "server_on_twstats": false
   },
   "reporting": {
@@ -19,37 +19,36 @@
     "token": ""
   },
   "bot": {
-    "active_hours": "6-23",
-    "delay_factor": 1.0,
-    "active_delay": 200,
+    "active_hours": "7-22",
+    "delay_factor": 1.6,
+    "active_delay": 375,
     "inactive_still_active": true,
-    "inactive_delay": 2000,
+    "inactive_delay": 3300,
     "add_new_villages": true,
     "village_name_template": "Village {num}",
     "village_name_number_length": 3,
     "auto_set_village_names": false,
-    "user_agent": null,
-    "check_update": true,
-    "farm_bag_limit_margin": 0.02
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+    "check_update": true
   },
   "building": {
     "manage_buildings": true,
-    "default": "purple_predator",
+    "default": "purple_predator_into_def",
     "max_lookahead": 2,
     "max_queued_items": 2
   },
   "units": {
     "recruit": true,
     "upgrade": true,
-    "default": "basic",
+    "default": "basic_into_def",
     "batch_size": 25,
     "manage_defence": false,
     "remove_manual_queued": false,
     "randomize_unit_queue": true
   },
   "village_template": {
-    "building": "purple_predator",
-    "units": "basic",
+    "building": "purple_predator_into_def",
+    "units": "basic_into_def",
     "managed": true,
     "scout_first": false,
     "additional_farms": [],
@@ -64,23 +63,22 @@
     "support_others": false,
     "support_others_factor": 0.25,
     "support_others_max_villages": 2,
-    "request_support_on_attack": false,
-    "farm_bag_limit_override": null
+    "request_support_on_attack": false
   },
   "farms": {
     "farm": true,
     "min_points": 0,
-    "max_points": 50,
+    "max_points": 150,
     "find_player_owned": false,
     "search_radius": 100,
-    "default_away_time": 3600,
-    "full_loot_away_time": 1800,
-    "low_loot_away_time": 7200,
+    "default_away_time": 4200,
+    "full_loot_away_time": 2400,
+    "low_loot_away_time": 9000,
     "max_farms": 25,
     "attack_higher_points": false,
     "force_scout_if_available": true,
     "forced_peace_times": [],
-    "farm_scout_amount": 5
+    "farm_scout_amount": 3
   },
   "market": {
     "auto_trade": true,
@@ -91,15 +89,33 @@
     "trade_max_per_hour": 1
   },
   "world": {
-    "knight_enabled": null,
-    "flags_enabled": null,
-    "quests_enabled": null,
+    "knight_enabled": true,
+    "flags_enabled": false,
+    "quests_enabled": true,
     "trade_for_premium": false,
-    "archers_enabled": true,
+    "archers_enabled": false,
     "building_destruction_enabled": true,
-    "boosters_enabled": null,
-    "farm_bag_limit_enabled": false,
-    "farm_bag_block_scouts": true
+    "boosters_enabled": true
   },
-  "villages": {}
+  "villages": {
+    "14818": {
+      "building": "purple_predator",
+      "units": "basic_into_def",
+      "managed": true,
+      "scout_first": false,
+      "additional_farms": [],
+      "prioritize_building": true,
+      "prioritize_snob": false,
+      "trade_for_premium": false,
+      "gather_enabled": false,
+      "gather_selection": 1,
+      "advanced_gather": true,
+      "snobs": 0,
+      "evacuate_fragile_units_on_attack": false,
+      "support_others": false,
+      "support_others_factor": 0.25,
+      "support_others_max_villages": 2,
+      "request_support_on_attack": false
+    }
+  }
 }

--- a/game/attack.py
+++ b/game/attack.py
@@ -268,8 +268,15 @@ class AttackManager:
             )
             return False
         troops = {"spy": self.scout_farm_amount}
-        if self.attack(vid, troops=troops, check_bag_limit=self.farm_bag_block_scouts):
-            self.attacked(vid, scout=True, safe=False)
+        result = self.attack(
+            vid,
+            troops=troops,
+            check_bag_limit=self.farm_bag_block_scouts,
+        )
+        if not result or result in ("farm_bag_full", "forced_peace"):
+            return False
+        self.attacked(vid, scout=True, safe=False)
+        return True
 
     def can_attack(self, vid, clear=False):
         """

--- a/game/attack.py
+++ b/game/attack.py
@@ -3,12 +3,13 @@ Attack manager
 Sounds dangerous but it just sends farms
 """
 
-from core.extractors import Extractor
+import json
 import logging
 import time
 from datetime import datetime
 from datetime import timedelta
 
+from core.extractors import Extractor
 from core.filemanager import FileManager
 
 
@@ -36,6 +37,13 @@ class AttackManager:
     scout_farm_amount = 5
 
     forced_peace_time = None
+
+    farm_bag_limit_enabled = False
+    farm_bag_block_scouts = True
+    farm_bag_limit_margin = 0.0
+    last_farm_bag_state = None
+    _farm_bag_limit_reached = False
+    _farm_bag_last_log = 0
 
     # blocks villages which cannot be attacked at the moment (too low points, beginners protection etc..)
     _unknown_ignored = []
@@ -99,12 +107,17 @@ class AttackManager:
         Send a farming run
         """
         target, _ = target
+        if self.farm_bag_limit_enabled and self._farm_bag_limit_reached:
+            self.logger.debug("Skipping farm target because farm bag limit was reached earlier")
+            return 0
         missing = self.enough_in_village(template)
         if not missing:
             cached = self.can_attack(vid=target["id"], clear=False)
             if cached:
                 attack_result = self.attack(target["id"], troops=template)
                 if attack_result == "forced_peace":
+                    return 0
+                if attack_result == "farm_bag_full":
                     return 0
                 self.logger.info(
                     "Attacking %s -> %s (%s)" ,self.village_id, target["id"], str(template)
@@ -236,13 +249,20 @@ class AttackManager:
         """
         Attempt to send scouts to a farm
         """
+        if (
+                self.farm_bag_limit_enabled
+                and self._farm_bag_limit_reached
+                and self.farm_bag_block_scouts
+        ):
+            self.logger.debug("Skipping scout because farm bag limit reached")
+            return False
         if "spy" not in self.troopmanager.troops or int(self.troopmanager.troops["spy"]) < self.scout_farm_amount:
             self.logger.debug(
                 "Cannot scout %s at the moment because insufficient unit: spy", vid
             )
             return False
         troops = {"spy": self.scout_farm_amount}
-        if self.attack(vid, troops=troops):
+        if self.attack(vid, troops=troops, check_bag_limit=self.farm_bag_block_scouts):
             self.attacked(vid, scout=True, safe=False)
 
     def can_attack(self, vid, clear=False):
@@ -337,12 +357,27 @@ class AttackManager:
                 return False
         return True
 
-    def attack(self, vid, troops=None):
+    def attack(self, vid, troops=None, check_bag_limit=True):
         """
         Send a TW attack
         """
         url = f"game.php?village={self.village_id}&screen=place&target={vid}"
         pre_attack = self.wrapper.get_url(url)
+        if not pre_attack:
+            return False
+        bag_state = Extractor.get_farm_bag_state(pre_attack)
+        if bag_state:
+            self.last_farm_bag_state = bag_state
+            if self.farm_bag_limit_enabled and check_bag_limit:
+                margin = max(0.0, min(1.0, self.farm_bag_limit_margin or 0.0))
+                threshold = bag_state["max"] * (1 - margin)
+                if bag_state["current"] >= threshold:
+                    self._farm_bag_limit_reached = True
+                    self._log_farm_bag_block(bag_state)
+                    self._push_farm_bag_state()
+                    return "farm_bag_full"
+            if bag_state["current"] < bag_state["max"]:
+                self._farm_bag_limit_reached = False
         pre_data = {}
         for u in Extractor.attack_form(pre_attack):
             k, v = u
@@ -393,7 +428,50 @@ class AttackManager:
             data=confirm_data,
         )
 
+        self._push_farm_bag_state()
         return result
+
+    def _push_farm_bag_state(self):
+        if not self.last_farm_bag_state:
+            return
+        current = self.last_farm_bag_state.get("current")
+        maximum = self.last_farm_bag_state.get("max")
+        if current is None or maximum is None:
+            return
+        pct = (current / maximum) if maximum else 0
+        payload = {
+            "current": current,
+            "max": maximum,
+            "pct": pct,
+        }
+        if self.wrapper and hasattr(self.wrapper, "reporter"):
+            self.wrapper.reporter.add_data(
+                self.village_id,
+                data_type="village.farm_bag",
+                data=json.dumps(payload),
+            )
+
+    def _log_farm_bag_block(self, state):
+        now_ts = time.time()
+        if now_ts - self._farm_bag_last_log < 300:
+            return
+        self._farm_bag_last_log = now_ts
+        current = state.get("current", 0)
+        maximum = state.get("max", 0)
+        pct = (current / maximum * 100) if maximum else 0
+        self.logger.info(
+            "Farm bag limit reached for village %s: %d/%d (%.2f%%)",
+            self.village_id,
+            current,
+            maximum,
+            pct,
+        )
+        if self.wrapper and hasattr(self.wrapper, "reporter"):
+            self.wrapper.reporter.report(
+                self.village_id,
+                "TWB_FARM_BAG_LIMIT",
+                f"Farm bag limit reached: {current}/{maximum}",
+            )
 
 
 class AttackCache:


### PR DESCRIPTION
…ere die Dokumentation. Der Farm-Manager stoppt nun automatisch Farm- und Scout-Läufe, wenn das weltweite Beutelimit erreicht ist. Konfigurierbare Parameter wurden in die Beispielkonfiguration und README aufgenommen.